### PR TITLE
Fix doc comment highlighting for language-cpp14 syntax

### DIFF
--- a/styles/syntax-base.less
+++ b/styles/syntax-base.less
@@ -182,6 +182,10 @@
         color: @syntax-text-color;
     }
 
+    &.syntax--documentation.syntax--cpp {
+        color: @syntax-comment-color;
+    }
+
     &.syntax--link {
         color: @zooce-red;
     }


### PR DESCRIPTION
Hi @Zooce,

I love your syntax theme and have been using it for a while now. I use it with [language-cpp14](https://github.com/jbw3/language-cpp14) and there was a problem with doc comments, which this should fix.

before:
![before](https://user-images.githubusercontent.com/15223705/39565339-6c42f12e-4e6c-11e8-83cf-efc6d7aa0b6d.png)

after:
![after](https://user-images.githubusercontent.com/15223705/39565346-72d2d676-4e6c-11e8-95fb-6ce9444ebd7a.png)

Thanks!
